### PR TITLE
Fix for FreeBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ ltmain.sh
 make.txt
 missing
 stamp-h1
+CMakeCache.txt
+CMakeFiles/*
+autom4te.cache/*
+cmake_install.cmake
+profile.ijs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,10 @@ if (DATA_INSTALL_PREFIX)
     add_definitions(-DPROFILE_PATH="${DATA_INSTALL_PREFIX}/profile.ijs")
 endif ()
 
-if (UNIX AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    add_definitions("-D_UNIX64")
+if (UNIX)
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+        add_definitions("-D_UNIX64")
+    endif ()
 endif ()
 
 check_library_exists(dl dlopen "" HAVE_DL)


### PR DESCRIPTION
- fix to the CMake file, so that 'amd64' is a recognized option for 64 bit (CMake uses 'uname -p')
- updated .gitignore to include CMake files
